### PR TITLE
Fix language switcher listener cleanup

### DIFF
--- a/src/shared/ui/languages/index.tsx
+++ b/src/shared/ui/languages/index.tsx
@@ -23,7 +23,7 @@ const Languages: React.FC = () => {
   useEffect(() => {
     document.addEventListener("mousedown", handleClickOutside);
     return () => {
-      document.addEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("mousedown", handleClickOutside);
     }
   }, [handleClickOutside])
   const handleLanguageChange = (language: string) => {


### PR DESCRIPTION
## Summary
- replace duplicate `addEventListener` in language switcher cleanup with `removeEventListener`
- prevent accumulating document `mousedown` listeners when the component rerenders or unmounts

## Testing
- npx tsc -b