### PR TITLE
Fix delivery access for users without role data

### DIFF
--- a/src/shared/lib/userRoles.ts
+++ b/src/shared/lib/userRoles.ts
@@ -3,7 +3,11 @@ import type { UserResponse } from "entities/users/types";
 const normalizeRoleValue = (value?: string) => value?.trim().toLowerCase() ?? "";
 
 const hasAnyRoleToken = (user: UserResponse | null, tokens: string[]) => {
-  if (!user?.role) return false;
+  if (!user) return false;
+
+  // Production can still return users without role data. Keep the legacy
+  // delivery flow available until role responses are fully deployed.
+  if (!user.role) return true;
 
   const alias = normalizeRoleValue(user.role.alias);
   const names = Object.values(user.role.name ?? {}).map((value) => normalizeRoleValue(value));


### PR DESCRIPTION
## Summary
- keep delivery role checks open for authenticated legacy users when `user.role` is missing
- preserve existing role-token checks once role data is present

## Testing
- `git diff --check` passed locally
- `npm run build` could not run in the local sandbox because Node fails before project startup with `EPERM: operation not permitted, lstat 'C:\Users\Anna'`

## Context
Prod can still return login users without role data while delivery screens already use `isAgentRole` / `isWarehouseRole`, which hides realization/scanning actions.